### PR TITLE
fix(search): prioritize migemo results over fuzzy-only in fuzzy_migemo mode

### DIFF
--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -22,15 +22,16 @@ fn fuzzy_migemo_filter(items: &[LaunchItem], query: &str) -> Vec<LaunchItem> {
     }
     let fuzzy = fuzzy_filter(items, query);
     let migemo = migemo_filter(items, query);
-    // fuzzy 結果を優先し、migemo にしか引っかからなかったものを後ろに追加
-    let fuzzy_names: std::collections::HashSet<&str> =
-        fuzzy.iter().map(|i| i.name.as_str()).collect();
-    let migemo_only: Vec<LaunchItem> = migemo
+    // migemo 結果を優先し、fuzzy にしか引っかからなかったものを後ろに追加
+    // ローマ字で日本語アイテムを検索する際に migemo マッチが fuzzy のみマッチより先に表示される
+    let migemo_names: std::collections::HashSet<&str> =
+        migemo.iter().map(|i| i.name.as_str()).collect();
+    let fuzzy_only: Vec<LaunchItem> = fuzzy
         .into_iter()
-        .filter(|i| !fuzzy_names.contains(i.name.as_str()))
+        .filter(|i| !migemo_names.contains(i.name.as_str()))
         .collect();
-    let mut result = fuzzy;
-    result.extend(migemo_only);
+    let mut result = migemo;
+    result.extend(fuzzy_only);
     result
 }
 
@@ -283,13 +284,26 @@ mod tests {
     }
 
     #[test]
-    fn fuzzy_migemo_fuzzy_results_come_first() {
-        // fuzzy-matched items should precede migemo-only items
+    fn fuzzy_migemo_migemo_results_come_first() {
+        // migemo-matched items should precede fuzzy-only items
+        // "fi" migemo-matches "firefox" (ASCII passthrough) so firefox still leads
         let items = vec![item("はじめに"), item("firefox")];
-        // "fi" fuzzy-matches "firefox"; migemo for "fi" unlikely to match Japanese
         let r = fuzzy_migemo_filter(&items, "fi");
         assert!(!r.is_empty());
         assert_eq!(r[0].name, "firefox");
+    }
+
+    #[test]
+    fn fuzzy_migemo_romaji_japanese_comes_first() {
+        // kadai (romaji) should surface 課題-containing item before fuzzy-only ASCII items
+        let items = vec![item("2026-04-11-課題hoge"), item("Task Manager")];
+        let r = fuzzy_migemo_filter(&items, "kadai");
+        let names: Vec<&str> = r.iter().map(|i| i.name.as_str()).collect();
+        assert!(names.contains(&"2026-04-11-課題hoge"), "migemo match should be included");
+        let pos = r.iter().position(|i| i.name == "2026-04-11-課題hoge").unwrap();
+        if let Some(fp) = r.iter().position(|i| i.name == "Task Manager") {
+            assert!(pos < fp, "migemo match should precede fuzzy-only match");
+        }
     }
 
     #[test]

--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -295,15 +295,29 @@ mod tests {
 
     #[test]
     fn fuzzy_migemo_romaji_japanese_comes_first() {
-        // kadai (romaji) should surface 課題-containing item before fuzzy-only ASCII items
-        let items = vec![item("2026-04-11-課題hoge"), item("Task Manager")];
+        // kadai (romaji) should surface 課題-containing item before fuzzy-only ASCII items.
+        // "k a d a i notes" is a deterministic fuzzy-only candidate: it has k,a,d,a,i as
+        // a subsequence but does not contain the string "kadai", so migemo won't match it.
+        let items = vec![item("2026-04-11-課題hoge"), item("k a d a i notes")];
         let r = fuzzy_migemo_filter(&items, "kadai");
         let names: Vec<&str> = r.iter().map(|i| i.name.as_str()).collect();
-        assert!(names.contains(&"2026-04-11-課題hoge"), "migemo match should be included");
-        let pos = r.iter().position(|i| i.name == "2026-04-11-課題hoge").unwrap();
-        if let Some(fp) = r.iter().position(|i| i.name == "Task Manager") {
-            assert!(pos < fp, "migemo match should precede fuzzy-only match");
-        }
+        assert!(
+            names.contains(&"2026-04-11-課題hoge"),
+            "migemo match should be included"
+        );
+        assert!(
+            names.contains(&"k a d a i notes"),
+            "fuzzy-only match should be included"
+        );
+        let jp_pos = r
+            .iter()
+            .position(|i| i.name == "2026-04-11-課題hoge")
+            .unwrap();
+        let fuzzy_pos = r.iter().position(|i| i.name == "k a d a i notes").unwrap();
+        assert!(
+            jp_pos < fuzzy_pos,
+            "migemo match should precede fuzzy-only match"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- In `fuzzy_migemo` mode, migemo-matched items were appended **after** all fuzzy results, burying Japanese items (e.g. `2026-04-11-課題hoge`) at the end of hundreds of system app fuzzy matches
- Reverse the ordering in `fuzzy_migemo_filter` so **migemo results come first**, fuzzy-only results follow
- Update the existing `fuzzy_migemo_fuzzy_results_come_first` test to reflect the new behavior (renamed to `fuzzy_migemo_migemo_results_come_first`)
- Add regression test `fuzzy_migemo_romaji_japanese_comes_first` for the exact user-reported case (`kadai` → `課題hoge`)

## Behavior change

| Query | Before | After |
|-------|--------|-------|
| `kadai` (romaji for 課題) | `課題hoge` buried after hundreds of fuzzy-matched apps | `課題hoge` appears first ✓ |
| `vsc` | `Visual Studio Code` first (no migemo match) | Same ✓ |
| `fi` | `firefox` first (fuzzy) | `firefox` first (migemo ASCII passthrough also matches) ✓ |

## Test plan

- [x] `cargo test search` — 32/32 tests pass
- [ ] Launch app with `fuzzy_migemo` + `scan_dirs` pointing to a directory of Japanese-named files, confirm romaji input surfaces them at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now prioritize Japanese/migemo matches ahead of general fuzzy-only matches, improving relevance for romaji queries.
* **Tests**
  * Updated and added tests to verify the new result ordering for romaji queries, ensuring Japanese matches appear before deterministic fuzzy-only matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->