### PR TITLE
docs(readme): add DeepWiki and Code Wiki badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![Release](https://img.shields.io/github/v/release/yukimemi/shun?style=flat-square)](https://github.com/yukimemi/shun/releases)
 [![License](https://img.shields.io/github/license/yukimemi/shun?style=flat-square)](LICENSE)
 [![Built with Tauri](https://img.shields.io/badge/built%20with-Tauri-blue?style=flat-square)](https://tauri.app)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/yukimemi/shun)
+[![View Code Wiki](https://img.shields.io/badge/View-Code_Wiki-4285F4?logo=google&style=flat-square)](https://codewiki.google/github.com/yukimemi/shun)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Release](https://img.shields.io/github/v/release/yukimemi/shun?style=flat-square)](https://github.com/yukimemi/shun/releases)
 [![License](https://img.shields.io/github/license/yukimemi/shun?style=flat-square)](LICENSE)
 [![Built with Tauri](https://img.shields.io/badge/built%20with-Tauri-blue?style=flat-square)](https://tauri.app)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/yukimemi/shun)
+[![Ask DeepWiki](https://img.shields.io/badge/Ask-DeepWiki-black?style=flat-square)](https://deepwiki.com/yukimemi/shun)
 [![View Code Wiki](https://img.shields.io/badge/View-Code_Wiki-4285F4?logo=google&style=flat-square)](https://codewiki.google/github.com/yukimemi/shun)
 
 </div>


### PR DESCRIPTION
## Summary
- Add **Ask DeepWiki** and **View Code Wiki** badges to the README's badge block.
- Both link to the corresponding AI-generated wiki pages so readers can chat-explore the codebase without cloning.

## Test plan
- [ ] GitHub renders both badges in the README preview
- [ ] DeepWiki link resolves to https://deepwiki.com/yukimemi/shun
- [ ] Code Wiki link resolves to https://codewiki.google/github.com/yukimemi/shun

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added badges to README linking to DeepWiki and Google Code Wiki for easy access to additional resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yukimemi/shun/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->