### PR TITLE
feat: unify Enter to launch the highlighted candidate across all sources

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -654,6 +654,10 @@
       e.preventDefault();
       if (filteredSlash.length > 0) {
         runSlashCommand(filteredSlash[selectedIndex] ?? filteredSlash[0]);
+      } else if (isPathQuery(query)) {
+        // Path: run the typed path itself so e.g. "~/Documents/" opens the
+        // folder even when the list is showing its children
+        launchItem(makePathItem(query), null);
       } else if (query && filtered.length > 0) {
         // Run the typed query as the base (non-history) item
         const baseItem = filtered.find((item) => item.source !== "History");
@@ -666,10 +670,9 @@
       } else if (filtered[selectedIndex]?.source === "Warning") {
         invoke("open_config", { name: filtered[selectedIndex].path });
       } else if (filtered[selectedIndex]) {
-        const item = isPathQuery(query)
-          ? makePathItem(query)
-          : filtered[selectedIndex];
-        launchItem(item, null);
+        // Run the highlighted candidate, unified across all sources
+        // (path's typed-query launch now lives in run_query / Shift+Enter)
+        launchItem(filtered[selectedIndex], null);
       }
     } else if (matchKey(e, keybindings.delete_word)) {
       e.preventDefault();


### PR DESCRIPTION
## Summary

In search mode, pressing Enter (confirm) on a path query used to launch the typed query via `makePathItem(query)`, ignoring the highlighted candidate, while every other source launched the highlighted candidate. This made paths behave inconsistently.

This unifies the behavior:
- **Enter (confirm)** now launches the highlighted candidate (`filtered[selectedIndex]`) for **all** sources, including paths.
- **Shift+Enter (run_query)** now launches the typed path itself for path queries (`makePathItem(query)`), so e.g. `~/Documents/` opens the folder even when the list is showing its children.

## Changes
- `src/routes/+page.svelte`: remove the path-only special-case in the `confirm` branch; add a path branch to `run_query`.

## Testing
- Frontend (vitest): 110 passed
- Rust: 143 passed
- `npm run build`: OK