### PR TITLE
fix: key config items by name in history sort and no-args launch

### DIFF
--- a/src-tauri/src/apps.rs
+++ b/src-tauri/src/apps.rs
@@ -35,6 +35,23 @@ pub enum ItemSource {
     History,
 }
 
+impl LaunchItem {
+    /// history への記録・参照に使うキーを返す。
+    /// - History アイテム（再実行）: `history_key`（`key\targs` 形式）をそのまま使う。
+    /// - Config アイテム: `name` を使う。複数の Config が同じ exe（例: `powershell`）を
+    ///   共有しても name で区別でき、recent_first / count_first が正しく効く。
+    /// - それ以外（ScanDir, Path, Url など）: `path` を使う。
+    pub fn history_lookup_key(&self) -> &str {
+        if let Some(hk) = &self.history_key {
+            hk
+        } else if matches!(self.source, ItemSource::Config) {
+            &self.name
+        } else {
+            &self.path
+        }
+    }
+}
+
 pub fn render_template(template: &str, ctx: &tera::Context) -> String {
     tera::Tera::one_off(template, ctx, false).unwrap_or_else(|_| template.to_string())
 }
@@ -1146,5 +1163,50 @@ mod tests {
         let result = launch_with_extra(&item, vec!["extra".to_string()], &Default::default());
         // On CI echo may or may not be available, so just assert no arg-construction panic
         let _ = result;
+    }
+
+    // --- history_lookup_key ---
+
+    fn lookup_item(
+        name: &str,
+        path: &str,
+        source: ItemSource,
+        history_key: Option<&str>,
+    ) -> LaunchItem {
+        LaunchItem {
+            name: name.to_string(),
+            path: path.to_string(),
+            args: vec![],
+            workdir: None,
+            source,
+            completion: CompletionType::None,
+            completion_list: vec![],
+            completion_command: None,
+            completion_search_mode: None,
+            history_key: history_key.map(String::from),
+            source_file: None,
+        }
+    }
+
+    #[test]
+    fn history_lookup_key_config_uses_name() {
+        // 同じ exe (powershell) を共有する Config アイテムでも name で区別される
+        let a = lookup_item("Install kanade", "powershell", ItemSource::Config, None);
+        let b = lookup_item("Get-DriveInfoView", "powershell", ItemSource::Config, None);
+        assert_eq!(a.history_lookup_key(), "Install kanade");
+        assert_eq!(b.history_lookup_key(), "Get-DriveInfoView");
+        assert_ne!(a.history_lookup_key(), b.history_lookup_key());
+    }
+
+    #[test]
+    fn history_lookup_key_non_config_uses_path() {
+        let item = lookup_item("script", "C:/scripts/foo.ps1", ItemSource::ScanDir, None);
+        assert_eq!(item.history_lookup_key(), "C:/scripts/foo.ps1");
+    }
+
+    #[test]
+    fn history_lookup_key_history_uses_history_key() {
+        let item = lookup_item("app › arg", "exe", ItemSource::History, Some("MyApp\targ"));
+        assert_eq!(item.history_lookup_key(), "MyApp\targ");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,8 +143,8 @@ fn sort_items_with_order(
     sort_order: &config::SortOrder,
 ) {
     items.sort_by(|a, b| {
-        let a_key = a.history_key.as_deref().unwrap_or(&a.path);
-        let b_key = b.history_key.as_deref().unwrap_or(&b.path);
+        let a_key = a.history_lookup_key();
+        let b_key = b.history_lookup_key();
         let (ac, at) = history::sort_key(hist, a_key);
         let (bc, bt) = history::sort_key(hist, b_key);
         if ac == 0 && bc == 0 {
@@ -268,15 +268,12 @@ fn launch_item(
             item.args.iter().chain(extra.iter()).cloned().collect()
         };
         // Config アイテムは name をキーに記録する（同じ exe を使う別エントリと区別するため）
-        let record_key = if matches!(item.source, apps::ItemSource::Config) {
-            &item.name
-        } else {
-            &item.path
-        };
+        let record_key = item.history_lookup_key();
         history::record_args(record_key, &history_args, history_max_items);
     } else {
         // args なし or History アイテムの再実行: そのままのキーで記録
-        let record_key = item.history_key.as_deref().unwrap_or(&item.path);
+        // Config アイテムは name をキーにする（同じ exe を共有する別アプリを区別するため）
+        let record_key = item.history_lookup_key();
         history::record(record_key, history_max_items);
     }
 


### PR DESCRIPTION
## Problem

After launching a config item, it does not move to the top under `recent_first` sort.

Concretely: `Install kanade` and `Get-DriveInfoView` are both config apps with `path = "powershell"` and fixed `-Command` args (no `{{ args }}` template). The history file collapsed them into a single shared entry:

```json
{ "key": "powershell", "count": 25, "last_used": ... }
```

Because the no-args launch `record()` and the sort frecency lookup both keyed by the executable `path` (`"powershell"`), the two items always had identical frecency. With `recent_first` the just-launched item could never win the tie, so it stayed wherever the stable sort had it.

## Root cause

The "config items use `item.name` as history key (to distinguish apps sharing the same executable)" rule was only implemented in the **args-present** path (`record_args`). The **no-args** `record()` path and the **sort lookup** still used `path`.

## Fix

Introduce `LaunchItem::history_lookup_key()`:

- History item -> `history_key` (the `key\targs` combined key)
- Config item -> `name`
- otherwise -> `path`

All record and sort call sites now go through it, so config apps sharing an executable are distinguished by name and `recent_first` / `count_first` work as expected.

Adds unit tests covering the config / non-config / history cases.

> Note: the existing shared `"powershell"` history entry becomes orphaned after this change; each config app is re-recorded correctly under its `name` the next time it is launched.

## Test

- `cargo check --tests`: clean
- `cargo fmt -- --check`: clean
- `cargo clippy` on the changed files (`apps.rs`, `lib.rs`): clean

(The full `cargo test` link step hits a pre-existing local mingw `ld` "export ordinal too large" limitation unrelated to this change; the Rust suite runs on CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how recent launch history is matched and recorded, making item lookup more consistent across different item types.
  * Fixed sorting behavior so items with the same priority now keep a more reliable and predictable order.
  * Launch actions now use a consistent history key, reducing cases where previously used items could be misidentified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->