### PR TITLE
fix: run typed URL on Shift+Enter instead of history entry

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -96,6 +96,21 @@ export function makePathItem(p) {
 }
 
 /**
+ * Returns true if the query looks like an http(s) URL.
+ */
+export function isUrlQuery(q) {
+  return q.startsWith("http://") || q.startsWith("https://");
+}
+
+/**
+ * Returns a synthetic Url item for http(s) URL queries.
+ */
+export function makeUrlItem(u) {
+  return { name: u, path: u, args: [], workdir: null,
+           source: "Url", completion: "none", completion_list: [], completion_command: null };
+}
+
+/**
  * Returns a synthetic Warning item shown when a config file has parse errors.
  */
 export function makeWarningItem(file, error) {

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { firstSepIdx, isPathQuery, matchKey, fuzzyMatch, shouldBypassTemplate, getEffectiveSearchMode, nextSearchMode, makePathItem, makeWarningItem, canHaveArgs, validateKeybindings, normalizeConfigFileName, completionMatches } from "./utils.js";
+import { firstSepIdx, isPathQuery, isUrlQuery, matchKey, fuzzyMatch, shouldBypassTemplate, getEffectiveSearchMode, nextSearchMode, makePathItem, makeUrlItem, makeWarningItem, canHaveArgs, validateKeybindings, normalizeConfigFileName, completionMatches } from "./utils.js";
 
 // --- firstSepIdx ---
 
@@ -394,6 +394,42 @@ describe("makePathItem", () => {
 
   it("creates a Path item with empty args and workdir", () => {
     const item = makePathItem("C:/Users");
+    expect(item.workdir).toBeNull();
+    expect(item.completion_list).toEqual([]);
+    expect(item.completion_command).toBeNull();
+  });
+});
+
+// --- isUrlQuery ---
+
+describe("isUrlQuery", () => {
+  it("returns true for http:// and https:// URLs", () => {
+    expect(isUrlQuery("http://example.com")).toBe(true);
+    expect(isUrlQuery("https://example.com")).toBe(true);
+  });
+
+  it("returns false for non-URL queries", () => {
+    expect(isUrlQuery("example.com")).toBe(false);
+    expect(isUrlQuery("~/Documents")).toBe(false);
+    expect(isUrlQuery("ftp://example.com")).toBe(false);
+    expect(isUrlQuery("")).toBe(false);
+  });
+});
+
+// --- makeUrlItem ---
+
+describe("makeUrlItem", () => {
+  it("creates a Url item with the given URL as both name and path", () => {
+    const item = makeUrlItem("https://example.com");
+    expect(item.name).toBe("https://example.com");
+    expect(item.path).toBe("https://example.com");
+    expect(item.source).toBe("Url");
+    expect(item.args).toEqual([]);
+    expect(item.completion).toBe("none");
+  });
+
+  it("creates a Url item with empty args and workdir", () => {
+    const item = makeUrlItem("http://localhost:3000");
     expect(item.workdir).toBeNull();
     expect(item.completion_list).toEqual([]);
     expect(item.completion_command).toBeNull();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import { getVersion } from "@tauri-apps/api/app";
   import { debug, info } from "@tauri-apps/plugin-log";
   import { onMount, onDestroy, tick } from "svelte";
-  import { firstSepIdx, isPathQuery, matchKey, fuzzyMatch, shouldBypassTemplate, getEffectiveSearchMode, nextSearchMode, makePathItem, makeWarningItem, canHaveArgs, validateKeybindings, normalizeConfigFileName, completionMatches } from "$lib/utils.js";
+  import { firstSepIdx, isPathQuery, isUrlQuery, matchKey, fuzzyMatch, shouldBypassTemplate, getEffectiveSearchMode, nextSearchMode, makePathItem, makeUrlItem, makeWarningItem, canHaveArgs, validateKeybindings, normalizeConfigFileName, completionMatches } from "$lib/utils.js";
   import { highlight, shikiTheme } from "$lib/highlight.js";
   import SearchModeIcon from "$lib/SearchModeIcon.svelte";
   import SortOrderIcon from "$lib/SortOrderIcon.svelte";
@@ -658,6 +658,11 @@
         // Path: run the typed path itself so e.g. "~/Documents/" opens the
         // folder even when the list is showing its children
         launchItem(makePathItem(query), null);
+      } else if (isUrlQuery(query)) {
+        // Url: run the typed URL itself, bypassing history candidates
+        // (history URLs share source "Url", so the generic base-item lookup
+        //  below would pick a history entry instead of what was typed)
+        launchItem(makeUrlItem(query), null);
       } else if (query && filtered.length > 0) {
         // Run the typed query as the base (non-history) item
         const baseItem = filtered.find((item) => item.source !== "History");
@@ -803,10 +808,10 @@
       resizeForSearch(filteredSlash.length);
       return;
     }
-    if (query.startsWith("http://") || query.startsWith("https://")) {
+    if (isUrlQuery(query)) {
       invoke("search_items", { query, searchMode: uiSearchMode, sortOrder: uiSortOrder }).then((results) => {
         // history 候補を先頭に、入力中の URL が候補にない場合は末尾に追加
-        const typed = { name: query, path: query, args: [], workdir: null, source: "Url", completion: "none", completion_list: [], completion_command: null };
+        const typed = makeUrlItem(query);
         const hasExact = results.some((r) => r.path === query);
         filtered = hasExact ? results : [...results, typed];
         restoreOrResetSelection(filtered);


### PR DESCRIPTION
## Problem

When a URL is typed into the launcher and **Shift+Enter** (`run_query`) is pressed, the launcher runs the first **history** URL instead of the freshly typed input.

## Cause

The `run_query` handler picks the item to launch with:

```js
const baseItem = filtered.find((item) => item.source !== "History");
```

For URL queries, history URL candidates carry `source === "Url"` (not `"History"`), and the typed URL is appended to the **end** of `filtered`. So `find` returns the first history entry rather than what the user typed.

## Fix

Add an `isUrlQuery` branch to `run_query` that launches `makeUrlItem(query)` directly — mirroring the existing path-query handling that runs the typed path itself. `isUrlQuery` and `makeUrlItem` are extracted into `utils.js` and reused by the search effect (replacing the inline duplicate).

## Tests

- New unit tests for `isUrlQuery` and `makeUrlItem` in `utils.test.js`
- `npm test` green (114 tests)

Note: `cargo make check` currently fails on pre-existing `clippy` lints in `config.rs` unrelated to this change (stricter clippy 1.95); this PR touches frontend only.