### PR TITLE
fix: avoid char boundary panic when checking the shell: prefix

### DIFF
--- a/src-tauri/src/apps.rs
+++ b/src-tauri/src/apps.rs
@@ -386,7 +386,15 @@ fn is_path(s: &str) -> bool {
         || (s.starts_with('$')
             && s.len() > 1
             && (s.as_bytes()[1].is_ascii_alphabetic() || s.as_bytes()[1] == b'_'))
-        || s.len() > 6 && s[..6].eq_ignore_ascii_case("shell:")
+        || is_shell_prefix(s)
+}
+
+/// Windows の `shell:` 特殊フォルダ指定かどうか。
+///
+/// バイト単位で比較する。`s[..6]` だと 6 バイト目がマルチバイト文字の途中
+/// (例: "ab日本語") のときに panic するため。
+pub fn is_shell_prefix(s: &str) -> bool {
+    s.len() > 6 && s.as_bytes()[..6].eq_ignore_ascii_case(b"shell:")
 }
 
 fn history_items(config: &Config) -> Vec<LaunchItem> {
@@ -840,6 +848,30 @@ mod tests {
         assert!(is_path("shell:RecycleBinFolder"));
         assert!(is_path("SHELL:startup"));
         assert!(!is_path("shell")); // コロンなし
+    }
+
+    #[test]
+    fn path_multibyte_name_does_not_panic() {
+        // 6 バイト目がマルチバイト文字の途中で終わる名前 (config の [[apps]] name が
+        // history キーとして渡ってくる) でも panic しないこと
+        assert!(!is_path("ab日本語"));
+        assert!(!is_path("AB検索 (2026)"));
+        assert!(!is_path("shellあいうえお"));
+        assert!(!is_path("あいうえお"));
+        // 境界ちょうどのケース
+        assert!(!is_path("日本"));
+        assert!(!is_path("日本語"));
+    }
+
+    #[test]
+    fn shell_prefix_helper() {
+        assert!(is_shell_prefix("shell:startup"));
+        assert!(is_shell_prefix("SHELL:startup"));
+        assert!(!is_shell_prefix("shell:")); // プレフィックスのみ
+        assert!(!is_shell_prefix("shell"));
+        // マルチバイト文字で panic しないこと
+        assert!(!is_shell_prefix("ab日本語"));
+        assert!(!is_shell_prefix("shellあいうえお"));
     }
 
     // --- render_template ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -301,7 +301,7 @@ fn launch_item(
         let expanded = utils::expand_path(path.trim_end_matches('/'));
         // Windows: shell: 特殊フォルダは explorer.exe 経由で起動
         #[cfg(target_os = "windows")]
-        if expanded.len() > 6 && expanded[..6].eq_ignore_ascii_case("shell:") {
+        if apps::is_shell_prefix(&expanded) {
             use std::os::windows::process::CommandExt;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             return std::process::Command::new("explorer.exe")


### PR DESCRIPTION
Fixes a crash where the app aborts a few seconds after launch.

## Cause

`is_path()` tested the `shell:` prefix with a byte-index slice:

```rust
|| s.len() > 6 && s[..6].eq_ignore_ascii_case("shell:")
```

`len()` and `s[..6]` are both byte-based, so when the 6th byte falls inside a multi-byte character the slice panics:

```
thread 'main' panicked at src\apps.rs:389:28:
end byte index 6 is not a char boundary; it is inside 'ト' (bytes 5..8 of string)
```

A config `[[apps]]` entry whose `name` is a non-ASCII string with that byte layout (two ASCII chars followed by CJK, for example) is enough to trigger it. The name is stored as the history key, and `history_items()` passes every key to `is_path()`, so once such an entry is launched once:

- `build_cache()` panics on every subsequent rebuild
- the background rebuild thread dies silently, so the app keeps running with a stale cache and simply stops logging `build_cache: done`
- at startup the cache build runs on the main thread, so the whole process aborts (`0xC0000409` / `FAST_FAIL_FATAL_APP_EXIT`) a few seconds in — the window never appears and the global shortcut does nothing

`launch_with_extra()` in `lib.rs` had the same byte-slicing pattern in the Windows `shell:` launch path.

## Changes

- compare as bytes via `<[u8]>::eq_ignore_ascii_case` in both places
- add a regression test covering multi-byte names

## Test plan

- CI (`cargo test`, `cargo clippy`, `npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012brepo7bbDbThfySAjeGxh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of shell paths containing multibyte characters.
  * Prevented crashes when processing certain non-ASCII path names.
  * Preserved case-insensitive recognition of shell paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->